### PR TITLE
Add link warning elimilation guide for upgrade gcc10 project to gcc13 project

### DIFF
--- a/9-modify_the_cproject_file_to_change_the_project_to_gcc13.md
+++ b/9-modify_the_cproject_file_to_change_the_project_to_gcc13.md
@@ -157,7 +157,11 @@ ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.other
 ```
 
 ## 增加link warning消除的配置
-在GCC 13使用过程中会产生很多的warning信息，可以在链接选项中增加-Wl,--no-warn-rwx-segments参数，用以频闭这些warning信息。
+
+在GCC 13使用过程中会产生很多的warning信息，可以在链接选项中额外增加`-Wl,--no-warn-rwx-segments`参数，用以关闭这些warning信息。
+
+具体参见 https://sourceware.org/binutils/docs/ld/Options.html#index-_002d_002dwarn_002drwx_002dsegments
+
 变更前`.cproject`文件的内容
 
 ```xml
@@ -172,5 +176,8 @@ ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.other
 
 
 完成以上变更后，reload一下工程，工程就可以在Nuclei Studio 2023.10下正常编译、调试、运行了。
-> 说明：
-> 本文档中，所有引用的例子中关于`.cproject`文件，出现的类似`id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other.1735566114"`中，`1735566114`是一个Nuclei Studio生成的hash值，不同时间不同工程各不相同，且其不引响配置，如果能保持与原值相同的情况下，尽量保持相同。
+
+> **说明**：
+> 
+> 本文档中，所有引用的例子中关于`.cproject`文件，出现的类似`id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other.1735566114"`中，
+> `1735566114`是一个Nuclei Studio生成的hash值，不同时间不同工程各不相同，且其不影响配置，如果能保持与原值相同的情况下，尽量保持相同。

--- a/9-modify_the_cproject_file_to_change_the_project_to_gcc13.md
+++ b/9-modify_the_cproject_file_to_change_the_project_to_gcc13.md
@@ -156,6 +156,21 @@ ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.other
 </option>
 ```
 
+## 增加link warning消除的配置
+在GCC 13使用过程中会产生很多的warning信息，为了频闭这些warning信息，可以在链接选项中增加-Wl,--no-warn-rwx-segments可以参数。
+变更前`.cproject`文件的内容
+
+```xml
+<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.other.1000044097" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.other" value="" valueType="string"/>
+```
+
+变更后`.cproject`文件的内容
+
+```xml
+<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.other.1000044097" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.other" value="-Wl,--no-warn-rwx-segments" valueType="string"/>
+```
+
+
 完成以上变更后，reload一下工程，工程就可以在Nuclei Studio 2023.10下正常编译、调试、运行了。
 > 说明：
 > 本文档中，所有引用的例子中关于`.cproject`文件，出现的类似`id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other.1735566114"`中，`1735566114`是一个Nuclei Studio生成的hash值，不同时间不同工程各不相同，且其不引响配置，如果能保持与原值相同的情况下，尽量保持相同。

--- a/9-modify_the_cproject_file_to_change_the_project_to_gcc13.md
+++ b/9-modify_the_cproject_file_to_change_the_project_to_gcc13.md
@@ -157,7 +157,7 @@ ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.other
 ```
 
 ## 增加link warning消除的配置
-在GCC 13使用过程中会产生很多的warning信息，为了频闭这些warning信息，可以在链接选项中增加-Wl,--no-warn-rwx-segments可以参数。
+在GCC 13使用过程中会产生很多的warning信息，可以在链接选项中增加-Wl,--no-warn-rwx-segments参数，用以频闭这些warning信息。
 变更前`.cproject`文件的内容
 
 ```xml


### PR DESCRIPTION
增加如何消除 link warning的方法，参见 https://stackoverflow.com/questions/73429929/gnu-linker-elf-has-a-load-segment-with-rwx-permissions-embedded-arm-project