### PR TITLE
docs: fix several typos, grammar and factual errors in supply docs

### DIFF
--- a/11-openocd_reported_error_not_known_as_fespi_capable.md
+++ b/11-openocd_reported_error_not_known_as_fespi_capable.md
@@ -1,4 +1,4 @@
-# Error Reported by OpenOCD When Flashing a Program: Error:Device ID 8xle2g8a6d is not known as FESPI capable
+# Error Reported by OpenOCD When Flashing a Program: Error: Device ID 0x1e200a6d is not known as FESPI capable
 
 ## Problem Description
 

--- a/12-nucleisdk-0.5.0-dhrystone-score-lower-than-expected-in-IDE.md
+++ b/12-nucleisdk-0.5.0-dhrystone-score-lower-than-expected-in-IDE.md
@@ -12,7 +12,7 @@ The detailed steps and screenshots are as follows:
 
 1. Download the **sdk-nuclei_sdk 0.5.0** NPK component package.
 
-2. Create a new **Nuclei RISCV-V C/C++ project**.
+2. Create a new **Nuclei RISC-V C/C++ project**.
 
 3. During project creation, select **Dhrystone Benchmark** and **N307FD Core**, and keep the default settings for the other options. If you build and run it directly at this point, the benchmark score is **1.405**.
 

--- a/15-unsatisfiedLinkError_of_swt-win32-4965r8_dll_on_windows7.md
+++ b/15-unsatisfiedLinkError_of_swt-win32-4965r8_dll_on_windows7.md
@@ -39,6 +39,9 @@ java.lang.UnsatisfiedLinkError: Could not load SWT library. Reasons:
 	
 ```
 
+> [!NOTE]
+> The version number in the SWT library file name (e.g., `swt-win32-4965r8.dll`, `swt-win32-4965r11.dll`) depends on the Eclipse/SWT plugin version bundled with each Nuclei Studio release. Different IDE versions ship with different SWT plugin versions, so the exact DLL name in your log may differ from the one in the title of this document.
+
 This is because Eclipse 2024.06 uses certain features that have specific operating system requirements. For details, refer to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1252
 
 ![](asserts/images/15/15-1.png)

--- a/17-an_example_to_demonstrate_the_use_of_profiling_and_code_coverage.md
+++ b/17-an_example_to_demonstrate_the_use_of_profiling_and_code_coverage.md
@@ -38,7 +38,7 @@ The following example demonstrates the latter method:
 
 **Step 1: Create a new Profiling demo project**
 
-`File->New->New Nuclei RISC-V C/C++ Project`, select `Nuclei FPGA Evalution Board->sdk-nuclei_sdk @0.6.0`
+`File->New->New Nuclei RISC-V C/C++ Project`, select `Nuclei FPGA Evaluation Board->sdk-nuclei_sdk @0.6.0`
 
 **Note:** Nuclei SDK version 0.6.0 or later must be selected to support the Profiling and Code coverage features
 
@@ -119,7 +119,7 @@ Start parsing the gprof data. **Note:** Some issues may be encountered in this s
 * Testing on qemu, with logs printed to the Console
 
 **Note**: qemu is only used for demonstration purposes. If accurate hotspot functions are desired, on-board testing is required.
-![call_prase_tools](asserts/images/17/call_prase_tools.png)   
+![call_parse_tools](asserts/images/17/call_prase_tools.png)   
 After parsing is complete, a gmon.out file is generated in the current project directory. Double-click to open it:  
 ![profiling_on_qemu](asserts/images/17/profiling_on_qemu.png)   
 
@@ -295,7 +295,7 @@ Clean the project and recompile, then run profiling again. You can see the optim
 **Note:** The above is only a simple example. Users can analyze and optimize the hotspot functions one by one. Due to sampling and other factors during execution,
 the distribution of TOP functions may fluctuate, which is normal. The final precise analysis requires counting the total number of cycles and then calculating the improvement ratio.
 
-### 2 Call Graph Feature
+### 3 Call Graph Feature
 
 The Call Graph in Nuclei Studio mainly obtains the function call relationships in the program by analyzing Profiling data.
 
@@ -327,7 +327,7 @@ It presents the program's time consumption relationships very intuitively in the
 
 ![Aggregate View](asserts/images/17/Aggregate_View.png)
 
-### 3 Code coverage Feature
+### 4 Code coverage Feature
 
 The Code coverage feature in Nuclei Studio is based on the gcov tool provided by the gcc compiler. During compilation, the specified source files must be compiled with the specific compiler option `-coverage`. After a successful build, an ELF file is obtained, which is then run on the actual development board to collect the required coverage files (gcda/gcno files), and finally the results are displayed graphically in the IDE.
 
@@ -365,13 +365,13 @@ Add the `-coverage` compiler option and recompile the code:
 
 You can run it in the qemu simulator or on the actual board (coverage statistics do not involve performance analysis, so either qemu or on-board testing works).  
 
-![prase coverage data](asserts/images/17/prase_coverage_data.png)  
+![parse coverage data](asserts/images/17/prase_coverage_data.png)  
 
 After parsing, gcda and gcno files are generated in the Debug->application folder; double-click to open them  
 
 ![coverage_result](asserts/images/17/coverage_result.png)  
 
-### 4 Additional Notes
+### 5 Additional Notes
 
 1. The Profiling and Code coverage features can be enabled at the same time. Simply add code that collects both Profiling data and Code coverage data, and add the `-pg -coverage` compiler options when compiling.
 

--- a/18-demonstrate_NICE_VNICE_acceleration_of_the_Nuclei_Model_through_profiling.md
+++ b/18-demonstrate_NICE_VNICE_acceleration_of_the_Nuclei_Model_through_profiling.md
@@ -41,7 +41,7 @@ This document uses the first method to create the project. Since this demo uses 
 
 #### step1: Create a new demo_vnice project
 
-File->New->New Nuclei RISC-V C/C++ Project, select Nuclei FPGA Evalution Board->sdk-nuclei_sdk @0.6.0
+File->New->New Nuclei RISC-V C/C++ Project, select Nuclei FPGA Evaluation Board->sdk-nuclei_sdk @0.6.0
 
 **Note:** Nuclei SDK version 0.6.0 or later is required
 
@@ -111,7 +111,7 @@ aes_ecb_encrypt
 
 In the backed-up `aes_demo_nice` project, the user needs to study the algorithmic characteristics of the hotspot functions and replace them with **NICE/VNICE** instructions to improve overall program performance.
 
-Add `#include "insn.h"` to the two C files `aes_dec.c` and `aes_dec.c`, which contain the **TOP5** hotspot functions of AES encryption/decryption, so that **NICE/VNICE** instruction replacements can be added.
+Add `#include "insn.h"` to the two C files `aes_dec.c` and `aes_enc.c`, which contain the **TOP5** hotspot functions of AES encryption/decryption, so that **NICE/VNICE** instruction replacements can be added.
 
 The **TOP1** hotspot function is `aes_mix_columns_dec`, which implements the inverse MixColumns of AES decryption. It takes a state matrix as input, performs the computation, and outputs the computed state matrix to the same address. It implements Load data, the inverse mix computation, and Store data. The code is as follows:
 
@@ -186,7 +186,7 @@ static void aes_mix_columns_dec(
 }
 ~~~
 
-The **TOP2** hotspot function is `aes_mix_columns_enc`, which, similar to TOP1, implements the inverse MixColumns of AES encryption. It likewise takes a state matrix as input, performs the computation, and outputs the computed state matrix to the same address:
+The **TOP2** hotspot function is `aes_mix_columns_enc`, which, similar to TOP1, implements the MixColumns of AES encryption. It likewise takes a state matrix as input, performs the computation, and outputs the computed state matrix to the same address:
 
 ~~~c
 static void aes_mix_columns_enc(
@@ -216,7 +216,7 @@ static void aes_mix_columns_enc(
 
 Considering that the instruction implementation may not be achievable with a single instruction, two **VNICE** instructions can be used to replace this algorithm: the first one loads 16 bytes of data into a Vector register, and the second one performs the computation and the store.
 
-The `opcode`, `funct3`, and `funct7` of the instructions can still be customized within the encoding fields. The first instruction uses `rd` to describe the Vector register and `rs1` to describe the input parameter address; the second instruction uses `rs1` to describe the input parameter address and `rs1` to describe the input Vector register. The inline assembly for the two **VNICE** instructions is written into `insn.h` and defined as follows:
+The `opcode`, `funct3`, and `funct7` of the instructions can still be customized within the encoding fields. The first instruction uses `rd` to describe the Vector register and `rs1` to describe the input parameter address; the second instruction uses `rs1` to describe the input parameter address and `rs2` to describe the input Vector register. The inline assembly for the two **VNICE** instructions is written into `insn.h` and defined as follows:
 
 ~~~c
 __STATIC_FORCEINLINE vint8m1_t __custom_vnice_load_v_i8m1 (uint8_t* addr)

--- a/20-quick_downloads_using_flash_programming.md
+++ b/20-quick_downloads_using_flash_programming.md
@@ -17,7 +17,7 @@ Version >= 202412 is required. Version 202502 is provided below.
 
 **step1: Create a project and program the bit file**
 
-Use version 0.7.1 of sdk-nuclei_sdk to create a u900 helloworld project. Select Simple Helloworld Demo, FLASH download mode, and U900 Core in sequence, then click Finsh.
+Use version 0.7.1 of sdk-nuclei_sdk to create a u900 helloworld project. Select Simple Helloworld Demo, FLASH download mode, and U900 Core in sequence, then click Finish.
 
 ![image-Ori_Project_Build](asserts/images/20/20.png)
 
@@ -81,7 +81,7 @@ Nuclei Studio supports multiple download modes: DDR, FLASH, FLASHXIP, ILM, and S
 
 The FLASH and FLASHXIP modes can be used by following the steps above, while DDR, ILM, and SRAM download to memory, which differs from Flash. The following uses ILM as an example.
 
-Click Nulcei Settings to open the page, select ILM in Download, and save.
+Click Nuclei Settings to open the page, select ILM in Download, and save.
 
 ![image-Ori_Project_Build](asserts/images/20/20-7.png)
 

--- a/5-update_npk_to_support_nucleistudio_202310.md
+++ b/5-update_npk_to_support_nucleistudio_202310.md
@@ -160,7 +160,7 @@ The final display effect when creating a project is as follows
 
 ## libncrt Upgrade
 
-libncrt has also changed somewhat compared to before. Before using libncrt in NPK, both the old and new versions of the SDK define a variable `stdclib` in **conifguration**,
+libncrt has also changed somewhat compared to before. Before using libncrt in NPK, both the old and new versions of the SDK define a variable `stdclib` in **configuration**,
 whose value is a dropdown box that allows selecting different values. The difference lies in how `stdclib` is used in `common_flags` or elsewhere after it is obtained.
 
 For some notes about `stdclib`, see [here](https://doc.nucleisys.com/nuclei_sdk/develop/buildsystem.html#stdclib)

--- a/6-gcc13_gen_rvv_instructions_when_rvv_enabled.md
+++ b/6-gcc13_gen_rvv_instructions_when_rvv_enabled.md
@@ -3,8 +3,8 @@
 ## Problem Description
 
 If you are using `Nuclei SDK 0.5.0` with Nuclei RISC-V Toolchain 2023.10, and
-when compile some examples with RVV enabled, it may generate rvv instructions
-which called auto-vectorzation.
+when compiling some examples with RVV enabled, it may generate RVV instructions,
+which is called auto-vectorization.
 
 Take `application/baremetal/benchmark/dhrystone` for example:
 
@@ -15,12 +15,12 @@ make CORE=nx900fd ARCH_EXT=v clean
 make CORE=nx900fd ARCH_EXT=v dasm
 ~~~
 
-Then if you check the `dhrystone.dasm`, you will be able to see rvv instructions:
+Then if you check the `dhrystone.dasm`, you will be able to see RVV instructions:
 
 ## Solution
 
-This auto generated instructions may affect your hardware performance, so if you want
-to disable it, you don't need to pass rvv extension when compile application.
+These auto-generated instructions may affect your hardware performance, so if you want
+to disable it, you don't need to pass the RVV extension when compiling the application.
 
 ~~~shell
 $ cat dhrystone.dasm |grep vs
@@ -39,6 +39,6 @@ $ cat dhrystone.dasm |grep vs
 
 You can check https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112537 for more details.
 
-In gcc 14.x, if you want to disable the RISC-V RVV automatic vectorization, you can use the options ``-fno-tree-loop-vectorize -fno-tree-slp-vectorize``.
+In GCC 14.x, if you want to disable the RISC-V RVV automatic vectorization, you can use the options ``-fno-tree-loop-vectorize -fno-tree-slp-vectorize``.
 
-In gcc 13.x, you need to pass ``--param=riscv-autovec-preference=none``
+In GCC 13.x, you need to pass ``--param=riscv-autovec-preference=none``.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Please create new doc based on [Doc Template](0-template.md)
 
 Click [this link](https://doc.nucleisys.com/nuclei_studio_supply/) to see online version.
 
-> If you find any spelling errors or imperfections in the documentation, you are welcome to submit a Pull Request or Issue to help us improve it!
-
 > If you come across any spelling errors or areas that need improvement in the document, feel free to submit a Pull Request or Issue to help us enhance it!
 
 ## Documents
@@ -42,7 +40,7 @@ Click [this link](https://doc.nucleisys.com/nuclei_studio_supply/) to see online
 - [8. Issues with OpenOCD when operating nor-flash larger than 16M-Byte](8-openocd_202310_flashloader_flaws.md)
 - [9. Upgrade the project toolchain to GCC 13 by modifying the .cproject file](9-modify_the_cproject_file_to_change_the_project_to_gcc13.md)
 - [10. Compiling projects with the command line in Nuclei Studio](10-compiling_projects_with_headless_in_nuclei_studio.md)
-- [11. Error reported when OpenOCD flashes a program: Error:Device ID 8xle2g8a6d is not known as FESPI capable](11-openocd_reported_error_not_known_as_fespi_capable.md)
+- [11. Error reported when OpenOCD flashes a program: Error: Device ID 0x1e200a6d is not known as FESPI capable](11-openocd_reported_error_not_known_as_fespi_capable.md)
 - [12. About the inconsistency between Dhrystone benchmark scores in the IDE and NSDK 0.5.0 command-line scores](12-nucleisdk-0.5.0-dhrystone-score-lower-than-expected-in-IDE.md)
 - [13. Error: Couldn't find an available hardware trigger / Error: can't add breakpoint: resource not available](13-error_could_not_find_an_available_hardware_trigger.md)
 - [14. cannot find -lncrt_balanced: No such file or directory](14-cannot_find_-lncrt_balanced_no_such_file_or_directory.md)


### PR DESCRIPTION
docs: fix typos, grammar and factual errors in supply docs

- 18: fix aes_enc.c filename and rs2 register in NICE/VNICE guide;
  correct forward MixColumns for AES encryption
- 17: fix duplicate section numbering (### 2 -> 3/4/5), "prase" alt
  typos and "Evalution" spelling
- 6: fix grammar in problem/solution description (when compiling,
  auto-vectorization, GCC/RVV capitalization)
- 20: fix Finish / Nuclei Settings typos
- 15: add note that SWT dll version varies with IDE release
- 12: fix RISCV-V typo
- 5: fix conifguration typo
- 11/README: fix garbled FESPI device ID (0x1e200a6d)
- README: drop duplicated translated blockquote